### PR TITLE
Fix connector configuration comparison

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,7 +148,6 @@ def configure_confluent_kafka_consumer(event, args):
         "path.format": args.path_format,
         "locale": args.locale,
         "timezone": args.timezone,
-        "name": args.connector_name,
     }
 
     # Confluent's Kafka consumer containers can take a while to start up the
@@ -180,6 +179,7 @@ def configure_confluent_kafka_consumer(event, args):
         response = requests.get(f"{api_base_url}/{args.connector_name}/config")
         logger.debug(response.text)
         current_config = json.loads(response.text)
+        current_config.pop("name")
         logger.debug(f"current connector config = {current_config}")
         logger.debug(f"requested connector config = {connector_config}")
         if current_config != connector_config:

--- a/main.py
+++ b/main.py
@@ -148,6 +148,7 @@ def configure_confluent_kafka_consumer(event, args):
         "path.format": args.path_format,
         "locale": args.locale,
         "timezone": args.timezone,
+        "name": args.connector_name,
     }
 
     # Confluent's Kafka consumer containers can take a while to start up the


### PR DESCRIPTION
The API returns the 'name' of a connector in its response. Add this
attribute to the configuration payload so that a comparison of
dictionaries will work correctly.